### PR TITLE
Fix locking for _properties initialization

### DIFF
--- a/src/BulkCopy/BulkCopyListReader.cs
+++ b/src/BulkCopy/BulkCopyListReader.cs
@@ -38,10 +38,10 @@ namespace IHomer.Common.BulkCopy
 
             _destinationTableName = string.IsNullOrWhiteSpace(destinationTableName) ? typeof(T).Name : destinationTableName;
 
-            if (_properties != null) return;
-
             lock (_thisLock)
             {
+                if (_properties != null) return;
+
                 using (var connection = new SqlConnection(connectionString))
                 {
                     Initialize(connection);


### PR DESCRIPTION
The check if _properties collection is initialized should happen inside the lock.
